### PR TITLE
environment CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+
+install:
+  # Anaconda3
+  - wget https://repo.anaconda.com/archive/Anaconda3-2019.10-Linux-x86_64.sh
+  - bash Anaconda3-2019.10-Linux-x86_64.sh -b -p ${HOME}/anaconda3
+  - echo 'export PATH="${HOME}/anaconda3/bin:$PATH"' >> ${HOME}/.bashrc
+  - . ${HOME}/.bashrc
+
+script:
+  - conda env create -f environment.yml


### PR DESCRIPTION
Creation of the conda venv must be tested. The service of choice is still TravisCI, mostly for its superior CLI client.

Closes #2